### PR TITLE
Standardize beams conventions between fftvis and matvis

### DIFF
--- a/fftvis/__init__.py
+++ b/fftvis/__init__.py
@@ -1,1 +1,1 @@
-from . import beam, optimize, utils, simulate
+from . import beams, optimize, utils, simulate

--- a/fftvis/beams.py
+++ b/fftvis/beams.py
@@ -1,6 +1,8 @@
 import jax
 import numpy as np
+from pyuvdata import UVBeam
 from jax import numpy as jnp
+
 
 c_ms = 299792458.0  # Speed of light in meters per second
 

--- a/fftvis/beams.py
+++ b/fftvis/beams.py
@@ -115,7 +115,7 @@ def _evaluate_beam(
     polarized: bool,
     freq: float,
     check: bool = False,
-    spline_opts: dict | None = None,
+    spline_opts: dict = None,
 ):
     """Evaluate the beam on the CPU. Simplified version of the `_evaluate_beam_cpu` function
     in matvis.

--- a/fftvis/beams.py
+++ b/fftvis/beams.py
@@ -1,5 +1,7 @@
 import jax
+import numpy as np
 from jax import numpy as jnp
+from pyuvdata import UVBeam
 
 c_ms = 299792458.0  # Speed of light in meters per second
 
@@ -102,3 +104,77 @@ def interpolate_beam(
         The beam values at the given frequencies.
     """
     raise NotImplementedError("Interpolation not yet implemented.")
+
+
+def _evaluate_beam(
+    A_s: np.ndarray,
+    beam_list: list[UVBeam],
+    az: np.ndarray,
+    za: np.ndarray,
+    polarized: bool,
+    freq: float,
+    check: bool = False,
+    spline_opts: dict | None = None,
+):
+    """Evaluate the beam on the CPU. Simplified version of the `_evaluate_beam_cpu` function
+    in matvis.
+
+    This function will either interpolate the beam to the given coordinates tx, ty,
+    or evaluate the beam there if it is an analytic beam.
+
+    Parameters
+    ----------
+    A_s
+        Array of shape (nax, nfeed, nbeam, nsrcs_up) that will be filled with beam
+        values.
+    beam_list
+        List of unique beams.
+    tx, ty
+        Coordinates to evaluate the beam at, in sin-projection.
+    polarized
+        Whether to use beam polarization.
+    freq
+        Frequency to interpolate beam to.
+    check
+        Whether to check that the beam has no inf/nan values. Set to False if you are
+        sure that the beam is valid, as it will be faster.
+    spline_opts
+        Extra options to pass to the RectBivariateSpline class when interpolating.
+    """
+    # Primary beam pattern using direct interpolation of UVBeam object
+    for i, bm in enumerate(beam_list):
+        kw = (
+            {
+                "reuse_spline": True,
+                "check_azza_domain": False,
+                "spline_opts": spline_opts,
+            }
+            if isinstance(bm, UVBeam)
+            else {}
+        )
+        if isinstance(bm, UVBeam) and not bm.future_array_shapes:
+            bm.use_future_array_shapes()
+
+        interp_beam = bm.interp(
+            az_array=az,
+            za_array=za,
+            freq_array=np.atleast_1d(freq),
+            **kw,
+        )[0]
+
+        if polarized:
+            interp_beam = interp_beam[:, :, 0, :]
+        else:
+            # Here we have already asserted that the beam is a power beam and
+            # has only one polarization, so we just evaluate that one.
+            interp_beam = np.sqrt(interp_beam[0, 0, 0, :])
+
+        A_s[:, :, i] = interp_beam
+
+        # Check for invalid beam values
+        if check:
+            sm = np.sum(A_s)
+            if np.isinf(sm) or np.isnan(sm):
+                raise ValueError("Beam interpolation resulted in an invalid value")
+
+    return A_s

--- a/fftvis/beams.py
+++ b/fftvis/beams.py
@@ -1,4 +1,5 @@
 import jax
+import numpy as np
 from jax import numpy as jnp
 
 c_ms = 299792458.0  # Speed of light in meters per second
@@ -102,6 +103,7 @@ def interpolate_beam(
         The beam values at the given frequencies.
     """
     raise NotImplementedError("Interpolation not yet implemented.")
+
 
 def _evaluate_beam(
     A_s: np.ndarray,

--- a/fftvis/optimize.py
+++ b/fftvis/optimize.py
@@ -1,5 +1,7 @@
 from jax import numpy as jnp
 
+import numpy as np
+
 
 def _compute_sky_with_beam():
     """ """

--- a/fftvis/simulate.py
+++ b/fftvis/simulate.py
@@ -318,12 +318,12 @@ def simulate_basis(
 
         # Simulate
         _vis = finufft.nufft3d3(
-            2 * np.pi * np.ravel(tY),
             2 * np.pi * np.ravel(tX),
+            2 * np.pi * np.ravel(tY),
             np.ravel(_eta),
             np.ravel(Isky[above_horizon]),
-            np.ravel(V * tF),
             np.ravel(U * tF),
+            np.ravel(V * tF),
             np.ravel(tF),
             modeord=0,
             eps=accuracy,

--- a/fftvis/simulate.py
+++ b/fftvis/simulate.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import matvis
 from . import utils, beams
 import numpy as np
 import finufft

--- a/fftvis/simulate.py
+++ b/fftvis/simulate.py
@@ -206,11 +206,11 @@ def simulate(
                 bly * freqs[ni] / utils.speed_of_light,
             )
             _vis[:, ni] = finufft.nufft2d3(
-                2 * np.pi * ty,
                 2 * np.pi * tx,
+                2 * np.pi * ty,
                 np.ascontiguousarray(i_sky[:, ni]),
-                v,
                 u,
+                v,
                 modeord=0,
                 eps=accuracy,
             )

--- a/fftvis/simulate.py
+++ b/fftvis/simulate.py
@@ -234,45 +234,19 @@ def simulate(
 
         if expand_vis:
             for bi, bls in enumerate(baselines):
-                if polarized:
-                    np.add.at(
-                        vis,
-                        (
-                            ti,
-                            np.arange(nfeeds),
-                            np.arange(nfeeds),
-                            bl_to_red_map[bls][:, 0],
-                            bl_to_red_map[bls][:, 1],
-                        ),
-                        _vis[..., bi, :],
-                    )
-                else:
-                    np.add.at(
-                        vis,
-                        (ti, bl_to_red_map[bls][:, 0], bl_to_red_map[bls][:, 1]),
-                        _vis[..., bi, :],
-                    )
+                np.add.at(
+                    vis,
+                    (ti, bl_to_red_map[bls][:, 0], bl_to_red_map[bls][:, 1]),
+                    _vis[..., bi, :],
+                )
 
                 # Add the conjugate, avoid auto baselines twice
                 if bls[0] != bls[1]:
-                    if polarized:
-                        np.add.at(
-                            vis,
-                            (
-                                ti,
-                                np.arange(nfeeds),
-                                np.arange(nfeeds),
-                                bl_to_red_map[bls][:, 0],
-                                bl_to_red_map[bls][:, 1],
-                            ),
-                            _vis[..., bi, :],
-                        )
-                    else:
-                        np.add.at(
-                            vis,
-                            (ti, bl_to_red_map[bls][:, 0], bl_to_red_map[bls][:, 1]),
-                            _vis[..., bi, :],
-                        )
+                    np.add.at(
+                        vis,
+                        (ti, bl_to_red_map[bls][:, 1], bl_to_red_map[bls][:, 0]),
+                        _vis[..., bi, :].conj(),
+                    )
         else:
             vis[ti] = _vis
 

--- a/fftvis/simulate.py
+++ b/fftvis/simulate.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from . import utils, beams
-import numpy as np
 import finufft
-from typing import Callable
+import numpy as np
 from matvis import conversions
 
+from . import utils, beams
+
+# Default accuracy for the non-uniform fast fourier transform based on precision
 default_accuracy_dict = {
     1: 6e-8,
     2: 1e-12,
@@ -32,25 +33,36 @@ def simulate_vis(
     ----------
     antpos : dict
         Dictionary of antenna positions
-    freqs : np.ndarray
-        Frequencies to evaluate visibilities at MHz.
     sources : np.ndarray
-        asdf
+        Intensity distribution of sources/pixels on the sky, assuming intensity
+        (Stokes I) only. The Stokes I intensity will be split equally between
+        the two linear polarization channels, resulting in a factor of 0.5 from
+        the value inputted here. This is done even if only one polarization
+        channel is simulated.
+    ra, dec : array_like
+        Arrays of source RA and Dec positions in radians. RA goes from [0, 2 pi]
+        and Dec from [-pi, +pi].
+    freqs : np.ndarray
+        Frequencies to evaluate visibilities in Hz.
+    lsts : np.ndarray
+        Local sidereal time in radians. Range is [0, 2 pi].
     beam : UVBeam
-        pass
-    crd_eq : np.ndarray
-        pass
-    eq2tops : np.ndarray
-        pass
+        Beam object to use for the array. Per-antenna beams are not yet supported.
+    baselines : list of tuples, default = None
+        If provided, only the baselines within the list will be simulated and array of shape
+        (nbls, nfreqs, ntimes) will be returned if polarized is False, and (nbls, nfreqs, ntimes, 2, 2) if polarized is True.
     precision : int, optional
        Which precision level to use for floats and complex numbers
        Allowed values:
        - 1: float32, complex64
        - 2: float64, complex128
-    use_redundancy : bool, default = True
-        If True,
-    check : bool, default = False
-        If True, perform checks on the input data array prior to
+    polarized : bool, optional
+        Whether to simulate polarized visibilities. If True, the output will have
+        shape (nfreqs, ntimes, 2, 2, nants, nants), and if False, the output will
+        have shape (nfreqs, ntimes, nants, nants).
+    latitude : float, optional
+        Latitude of the array in radians. The default is the
+        HERA latitude = -30.7215 * pi / 180.
     eps : float, default = None
         Desired accuracy of the non-uniform fast fourier transform. If None, the default accuracy
         for the given precision will be used. For precision 1, the default accuracy is 6e-8, and for

--- a/fftvis/simulate.py
+++ b/fftvis/simulate.py
@@ -8,6 +8,11 @@ import numpy as np
 from typing import Callable
 from matvis import conversions
 
+default_accuracy_dict = {
+    1: 6e-8,
+    2: 1e-12,
+}
+
 
 def simulate_vis(
     antpos: dict,
@@ -21,7 +26,7 @@ def simulate_vis(
     precision: int = 1,
     polarized: bool = False,
     latitude: float = -0.5361913261514378,
-    accuracy: float = 1e-6,
+    accuracy: float = None,
 ):
     """
     Parameters:
@@ -47,14 +52,19 @@ def simulate_vis(
         If True,
     check : bool, default = False
         If True, perform checks on the input data array prior to
-    accuracy : float, default = 1e-6
-        pass
+    accuracy : float, default = None
+        Desired accuracy of the non-uniform fast fourier transform. If None, the default accuracy
+        for the given precision will be used. For precision 1, the default accuracy is 6e-8, and for
+        precision 2, the default accuracy is 1e-12.
 
     Returns:
     -------
     vis : np.ndarray
 
     """
+    if accuracy is None:
+        accuracy = default_accuracy_dict[precision]
+
     # Source coordinate transform, from equatorial to Cartesian
     crd_eq = conversions.point_source_crd_eq(ra, dec)
 

--- a/fftvis/simulate.py
+++ b/fftvis/simulate.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
 from . import utils
-import numpy as np
-from typing import Callable
-from matvis import conversions
 
 import finufft
 import numpy as np
@@ -89,7 +86,6 @@ def _evaluate_beam(
     }
     # Primary beam pattern using direct interpolation of UVBeam object
     az, za = conversions.enu_to_az_za(enu_e=tx, enu_n=ty, orientation="uvbeam")
-    # beam_vals = beam.interp(az_array=az, za_array=za, freq_array=freqs, **kw)[0][0, 0].T
     beam_vals = beam.interp(az_array=az, za_array=za, freq_array=freqs, **kw)[0][0, 1].T
     return beam_vals**2
 
@@ -105,7 +101,6 @@ def simulate(
     precision: int = 1,
     polarized: bool = False,
     use_redundancy: bool = True,
-    check: bool = False,
     accuracy: float = 1e-6,
 ):
     """
@@ -130,8 +125,6 @@ def simulate(
        - 2: float64, complex128
     use_redundancy : bool, default = True
         If True,
-    check : bool, default = False
-        If True, perform checks on the input data array prior to
     accuracy : float, default = 1e-6
         pass
 
@@ -141,18 +134,10 @@ def simulate(
 
     """
     # Check inputs are valid
-    if check:
-        nax, nfeeds, nants, ntimes = _validate_inputs(
-            precision, polarized, antpos, eq2tops, crd_eq, sources
-        )
-    else:
-        nax, nfeeds, nants, ntimes, nfreqs = (
-            1,
-            1,
-            len(antpos),
-            eq2tops.shape[0],
-            freqs.shape[0],
-        )
+    nfreqs = np.size(freqs)
+    nax, nfeeds, nants, ntimes = matvis._validate_inputs(
+        precision, polarized, antpos, eq2tops, crd_eq, sources
+    )
 
     if precision == 1:
         real_dtype = np.float32

--- a/fftvis/simulate.py
+++ b/fftvis/simulate.py
@@ -280,8 +280,10 @@ def simulate(
                         (ti, bl_to_red_map[bls][:, 1], bl_to_red_map[bls][:, 0]),
                         _vis[..., bi, :].conj(),
                     )
+                # else:
+                #    vis[ti, bi] = _vis[..., bi, :]
         else:
-            vis[ti] = _vis
+            vis[ti] = np.swapaxes(_vis, 2, 0)
 
     if expand_vis:
         return (

--- a/fftvis/tests/test_simulate.py
+++ b/fftvis/tests/test_simulate.py
@@ -38,7 +38,45 @@ def test_simulate():
 
     # Use fftvis to simulate visibilities
     fvis = simulate.simulate_vis(
-        antpos, sky_model, ra, dec, freqs, lsts, beam, precision=2, accuracy=1e-10
+        antpos, sky_model, ra, dec, freqs, lsts, beam, precision=2, eps=1e-10
     )
 
-    # assert np.allclose(mvis, fvis, atol=1e-5)
+    # Should have shape (nfreqs, ntimes, nants, nants)
+    assert fvis.shape == (nfreqs, ntimes, nants, nants)
+
+    # Check that the results are the same
+    assert np.allclose(mvis, fvis, atol=1e-5)
+
+    # Test polarized visibilities
+    # Use matvis as a reference
+    mvis = matvis.simulate_vis(
+        antpos,
+        sky_model,
+        ra,
+        dec,
+        freqs,
+        lsts,
+        beams=[beam],
+        precision=2,
+        polarized=True,
+    )
+
+    # Use fftvis to simulate visibilities
+    fvis = simulate.simulate_vis(
+        antpos,
+        sky_model,
+        ra,
+        dec,
+        freqs,
+        lsts,
+        beam,
+        precision=2,
+        eps=1e-10,
+        polarized=True,
+    )
+
+    # Should have shape (nfreqs, ntimes, nfeeds, nfeeds, nants, nants)
+    assert fvis.shape == (nfreqs, ntimes, 2, 2, nants, nants)
+
+    # Check that the polarized results are the same
+    assert np.allclose(mvis, fvis, atol=1e-5)

--- a/fftvis/tests/test_simulate.py
+++ b/fftvis/tests/test_simulate.py
@@ -80,3 +80,43 @@ def test_simulate():
 
     # Check that the polarized results are the same
     assert np.allclose(mvis, fvis, atol=1e-5)
+
+    # Simulate with specified baselines
+    sim_baselines = [(0, 1), (0, 2), (1, 2)]
+    fvis = simulate.simulate_vis(
+        antpos,
+        sky_model,
+        ra,
+        dec,
+        freqs,
+        lsts,
+        beam,
+        baselines=sim_baselines,
+        precision=2,
+        eps=1e-10,
+        polarized=True,
+    )
+
+    # Should have shape (nfreqs, ntimes, 2, 2, len(sim_baselines))
+    assert fvis.shape == (nfreqs, ntimes, 2, 2, len(sim_baselines))
+
+    # Check that the polarized results are the same
+    for bi, bl in enumerate(sim_baselines):
+        assert np.allclose(fvis[:, :, :, :, bi], mvis[:, :, :, :, bl[0], bl[1]])
+
+    # Test with precision 1
+    # Use matvis as a reference
+    mvis = matvis.simulate_vis(
+        antpos, sky_model, ra, dec, freqs, lsts, beams=[beam], precision=1
+    )
+
+    # Use fftvis to simulate visibilities
+    fvis = simulate.simulate_vis(
+        antpos, sky_model, ra, dec, freqs, lsts, beam, precision=1, eps=6e-8
+    )
+
+    # Should have shape (nfreqs, ntimes, nants, nants)
+    assert fvis.shape == (nfreqs, ntimes, nants, nants)
+
+    # Check that the results are the same
+    assert np.allclose(mvis, fvis, atol=1e-5)

--- a/fftvis/utils.py
+++ b/fftvis/utils.py
@@ -22,10 +22,11 @@ def get_pos_reds(antpos, decimals=3, include_autos=True):
         reds: list (sorted by baseline legnth) of lists of redundant tuples of antenna indices (no polarizations),
         sorted by index with the first index of the first baseline the lowest in the group.
     """
-
+    # Create a dictionary of redundant baseline groups
     uv_to_red_key = {}
     reds = {}
 
+    # Compute baseline lengths and round to specified precision
     baselines = np.round(
         [
             antpos[aj] - antpos[ai]

--- a/fftvis/utils.py
+++ b/fftvis/utils.py
@@ -3,105 +3,53 @@ import numpy as np
 IDEALIZED_BL_TOL = 1e-8  # bl_error_tol for redcal.get_reds when using antenna positions calculated from reds
 speed_of_light = 299792458.0  # m/s
 
-def reverse_bl(bl):
-    """Reverses a (i,j) or (i,j,pol) baseline key to make (j,i)
-    or (j,i,pol[::-1]), respectively."""
-    i, j = bl[:2]
-    return (j, i)
 
-
-def get_pos_reds(antpos, bl_error_tol=1.0, include_autos=False):
+def get_pos_reds(antpos, decimals=3, include_autos=False):
     """Figure out and return list of lists of redundant baseline pairs. Ordered by length. All baselines
     in a group have the same orientation with a preference for positive b_y and, when b_y==0, positive
     b_x where b((i,j)) = pos(j) - pos(i).
 
-    Args:
-        antpos: dictionary of antenna positions in the form {ant_index: np.array([x,y,z])}. 1D and 2D also OK.
-        bl_error_tol: the largest allowable difference between baselines in a redundant group
-            (in the same units as antpos). Normally, this is up to 4x the largest antenna position error.
+    Parameters:
+    ----------
+        antpos: dict
+            dictionary of antenna positions in the form {ant_index: np.array([x,y,z])}. 1D and 2D also OK.
+        decimals: int, optional
+            Number of decimal places to round to when determining redundant baselines. default is 3.
         include_autos: bool, optional
             if True, include autos in the list of pos_reds. default is False
     Returns:
+    -------
         reds: list (sorted by baseline legnth) of lists of redundant tuples of antenna indices (no polarizations),
         sorted by index with the first index of the first baseline the lowest in the group.
     """
-    keys = list(antpos.keys())
+
+    uv_to_red_key = {}
     reds = {}
-    assert np.all(
-        [len(pos) <= 3 for pos in antpos.values()]
-    ), "Get_pos_reds only works in up to 3 dimensions."
-    ap = {
-        ant: np.pad(pos, (0, 3 - len(pos)), mode="constant")
-        for ant, pos in antpos.items()
-    }  # increase dimensionality
-    array_is_flat = np.all(
-        np.abs(
-            np.array(list(ap.values()))[:, 2] - np.mean(list(ap.values()), axis=0)[2]
-        )
-        < bl_error_tol / 4.0
+
+    baselines = np.round(
+        [
+            antpos[aj] - antpos[ai]
+            for ai in antpos
+            for aj in antpos
+            if ai < aj or include_autos and ai == aj
+        ],
+        decimals,
     )
-    p_or_m = (0, -1, 1)
-    if array_is_flat:
-        epsilons = [[dx, dy, 0] for dx in p_or_m for dy in p_or_m]
-    else:
-        epsilons = [[dx, dy, dz] for dx in p_or_m for dy in p_or_m for dz in p_or_m]
 
-    def check_neighbors(
-        delta,
-    ):  # Check to make sure reds doesn't have the key plus or minus rounding error
-        for epsilon in epsilons:
-            newKey = (
-                delta[0] + epsilon[0],
-                delta[1] + epsilon[1],
-                delta[2] + epsilon[2],
-            )
-            if newKey in reds:
-                return newKey
-        return
+    ci = 0
+    for ai in antpos:
+        for aj in antpos:
+            if ai < aj or include_autos and ai == aj:
+                u, v, _ = baselines[ci]
 
-    for i, ant1 in enumerate(keys):
-        if include_autos:
-            start_ind = i
-        else:
-            start_ind = i + 1
-        for ant2 in keys[start_ind:]:
-            bl_pair = (ant1, ant2)
-            delta = tuple(
-                np.round(
-                    1.0 * (np.array(ap[ant2]) - np.array(ap[ant1])) / bl_error_tol
-                ).astype(int)
-            )
-            new_key = check_neighbors(delta)
-            if new_key is None:  # forward baseline has no matches
-                new_key = check_neighbors(tuple([-d for d in delta]))
-                if new_key is not None:  # reverse baseline does have a match
-                    bl_pair = (ant2, ant1)
-            if (
-                new_key is not None
-            ):  # either the forward or reverse baseline has a match
-                reds[new_key].append(bl_pair)
-            else:  # this baseline is entirely new
-                if (
-                    delta[0] <= 0
-                    or (delta[0] == 0 and delta[1] <= 0)
-                    or (delta[0] == 0 and delta[1] == 0 and delta[2] <= 0)
-                ):
-                    delta = tuple([-d for d in delta])
-                    bl_pair = (ant2, ant1)
-                reds[delta] = [bl_pair]
+                if (u, v) not in uv_to_red_key and (-u, -v) not in uv_to_red_key:
+                    reds[(ai, aj)] = [(ai, aj)]
+                    uv_to_red_key[(u, v)] = (ai, aj)
+                elif (-u, -v) in uv_to_red_key:
+                    reds[uv_to_red_key[(-u, -v)]].append((aj, ai))
+                elif (u, v) in uv_to_red_key:
+                    reds[uv_to_red_key[(u, v)]].append((ai, aj))
 
-    # sort reds by length and each red to make sure the first antenna of the first bl in each group is the lowest antenna number
-    orderedDeltas = [
-        delta
-        for (length, delta) in sorted(
-            zip([np.linalg.norm(delta) for delta in reds.keys()], reds.keys())
-        )
-    ]
-    return [
-        (
-            sorted(reds[delta])
-            if sorted(reds[delta])[0][0] == np.min(reds[delta])
-            else sorted([reverse_bl(bl) for bl in reds[delta]])
-        )
-        for delta in orderedDeltas
-    ]
+                ci += 1
+
+    return [reds[k] for k in reds]

--- a/fftvis/utils.py
+++ b/fftvis/utils.py
@@ -5,21 +5,22 @@ speed_of_light = 299792458.0  # m/s
 
 
 def get_pos_reds(antpos, decimals=3, include_autos=True):
-    """Figure out and return list of lists of redundant baseline pairs. Ordered by length. All baselines
-    in a group have the same orientation with a preference for positive b_y and, when b_y==0, positive
-    b_x where b((i,j)) = pos(j) - pos(i).
+    """
+    Figure out and return list of lists of redundant baseline pairs. This function is a modified version of the
+    get_pos_reds function in redcal. It is used to calculate the redundant baseline groups from antenna positions
+    rather than from a list of baselines. This is useful for simulating visibilities with fftvis.
 
     Parameters:
     ----------
         antpos: dict
-            dictionary of antenna positions in the form {ant_index: np.array([x,y,z])}. 1D and 2D also OK.
+            dictionary of antenna positions in the form {ant_index: np.array([x,y,z])}.
         decimals: int, optional
             Number of decimal places to round to when determining redundant baselines. default is 3.
         include_autos: bool, optional
             if True, include autos in the list of pos_reds. default is False
     Returns:
     -------
-        reds: list (sorted by baseline legnth) of lists of redundant tuples of antenna indices (no polarizations),
+        reds: list of lists of redundant tuples of antenna indices (no polarizations),
         sorted by index with the first index of the first baseline the lowest in the group.
     """
     # Create a dictionary of redundant baseline groups

--- a/fftvis/utils.py
+++ b/fftvis/utils.py
@@ -4,7 +4,7 @@ IDEALIZED_BL_TOL = 1e-8  # bl_error_tol for redcal.get_reds when using antenna p
 speed_of_light = 299792458.0  # m/s
 
 
-def get_pos_reds(antpos, decimals=3, include_autos=False):
+def get_pos_reds(antpos, decimals=3, include_autos=True):
     """Figure out and return list of lists of redundant baseline pairs. Ordered by length. All baselines
     in a group have the same orientation with a preference for positive b_y and, when b_y==0, positive
     b_x where b((i,j)) = pos(j) - pos(i).

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ setup(
         "numpy",
         "matvis",
         "finufft",
+        "pyuvdata",
+        "jax",
+        "jaxlib",
     ],
     python_requires=">=3.9",
     classifiers=[


### PR DESCRIPTION
`fftvis` currently has its own functions for handling antenna beams. This PR integrates `matvis` beam functions into `fftvis` to build consistency between `matvis` and `fftvis`.