### PR TITLE
fix get_pos_red to restrict to one side of the uv-plane

### DIFF
--- a/fftvis/utils.py
+++ b/fftvis/utils.py
@@ -54,4 +54,14 @@ def get_pos_reds(antpos, decimals=3, include_autos=True):
 
                 ci += 1
 
-    return [reds[k] for k in reds]
+    reds_list = []
+    for k in reds:
+        red = reds[k]
+        ant1, ant2 = red[0]
+        _, bly, _ = antpos[ant2] - antpos[ant1]
+        if bly < 0:
+            reds_list.append([(bl[1], bl[0]) for bl in red])
+        else:
+            reds_list.append(red)
+
+    return reds_list


### PR DESCRIPTION
This PR makes a small change to `get_pos_red` that restricts the baselines to one side of the uv-plane. The old method arbitrarily selected redundant baselines that were on either side of the uv-plane. This fix decreases the FFT runtime by a factor of ~2 for the full HERA array with outriggers.