### PR TITLE
Improve simulations functions to handle arrays that are non-coplanar

### DIFF
--- a/fftvis/simulate.py
+++ b/fftvis/simulate.py
@@ -239,6 +239,14 @@ def simulate(
     else:
         vis = np.zeros((ntimes, nbls, nfeeds, nfeeds, nfreqs), dtype=complex_dtype)
 
+    blx /= utils.speed_of_light
+    bly /= utils.speed_of_light
+    blz /= utils.speed_of_light
+
+    u = np.zeros_like(blx)
+    v = np.zeros_like(bly)
+    w = np.zeros_like(blz)
+
     # Have up to 100 reports as it iterates through time.
     report_chunk = ntimes // max_progress_reports + 1
     pr = psutil.Process()
@@ -284,11 +292,7 @@ def simulate(
 
             for fi in range(nfreqs):
                 # Compute uv coordinates
-                u, v, w = (
-                    blx * freqs[fi] / utils.speed_of_light,
-                    bly * freqs[fi] / utils.speed_of_light,
-                    blz * freqs[fi] / utils.speed_of_light,
-                )
+                u[:], v[:], w[:] = blx * freqs[fi], bly * freqs[fi], blz * freqs[fi]
 
                 # Compute beams - only single beam is supported
                 A_s = np.zeros((nax, nfeeds, nsim_sources), dtype=complex_dtype)

--- a/fftvis/tests/test_compare_matvis.py
+++ b/fftvis/tests/test_compare_matvis.py
@@ -14,7 +14,7 @@ def test_simulate():
     nsrcs = 20
 
     # Set random set
-    np.random.seed(42)
+    rng = np.random.default_rng(42)
 
     # Define frequency and time range
     freqs = np.linspace(100e6, 200e6, nfreqs)
@@ -29,7 +29,7 @@ def test_simulate():
     # Set sky model
     ra = np.linspace(0.0, 2.0 * np.pi, nsrcs)
     dec = np.linspace(-0.5 * np.pi, 0.5 * np.pi, nsrcs)
-    sky_model = np.random.uniform(0, 1, size=(nsrcs, 1)) * (freqs[None] / 150e6) ** -2.5
+    sky_model = rng.uniform(0, 1, size=(nsrcs, 1)) * (freqs[None] / 150e6) ** -2.5
 
     # Use matvis as a reference
     mvis = matvis.simulate_vis(
@@ -130,7 +130,7 @@ def test_simulate_non_coplanar():
     nsrcs = 20
 
     # Set random set
-    np.random.seed(42)
+    rng = np.random.default_rng(42)
 
     # Define frequency and time range
     freqs = np.linspace(100e6, 200e6, nfreqs)
@@ -145,7 +145,7 @@ def test_simulate_non_coplanar():
     # Set sky model
     ra = np.linspace(0.0, 2.0 * np.pi, nsrcs)
     dec = np.linspace(-0.5 * np.pi, 0.5 * np.pi, nsrcs)
-    sky_model = np.random.uniform(0, 1, size=(nsrcs, 1)) * (freqs[None] / 150e6) ** -2.5
+    sky_model = rng.uniform(0, 1, size=(nsrcs, 1)) * (freqs[None] / 150e6) ** -2.5
 
     # Use matvis as a reference
     mvis = matvis.simulate_vis(

--- a/fftvis/tests/test_compare_matvis.py
+++ b/fftvis/tests/test_compare_matvis.py
@@ -120,3 +120,42 @@ def test_simulate():
 
     # Check that the results are the same
     assert np.allclose(mvis, fvis, atol=1e-5)
+
+
+def test_simulate_non_coplanar():
+    # Simulation parameters
+    ntimes = 10
+    nfreqs = 5
+    nants = 3
+    nsrcs = 20
+
+    # Set random set
+    np.random.seed(42)
+
+    # Define frequency and time range
+    freqs = np.linspace(100e6, 200e6, nfreqs)
+    lsts = np.linspace(0, np.pi, ntimes)
+
+    # Set up the antenna positions
+    antpos = {k: np.array([k * 10, 0, k]) for k in range(nants)}
+
+    # Define a Gaussian beam
+    beam = AnalyticBeam("gaussian", diameter=14.0)
+
+    # Set sky model
+    ra = np.linspace(0.0, 2.0 * np.pi, nsrcs)
+    dec = np.linspace(-0.5 * np.pi, 0.5 * np.pi, nsrcs)
+    sky_model = np.random.uniform(0, 1, size=(nsrcs, 1)) * (freqs[None] / 150e6) ** -2.5
+
+    # Use matvis as a reference
+    mvis = matvis.simulate_vis(
+        antpos, sky_model, ra, dec, freqs, lsts, beams=[beam], precision=2
+    )
+
+    # Use fftvis to simulate visibilities
+    fvis = simulate.simulate_vis(
+        antpos, sky_model, ra, dec, freqs, lsts, beam, precision=2, eps=1e-10
+    )
+
+    # Check that the results are the same
+    assert np.allclose(mvis, fvis, atol=1e-5)


### PR DESCRIPTION
`fftvis.simulate.simulate` assumed that antenna layouts were always coplanar. This extends the simulation function to handle non-coplanar arrays.