### PR TITLE
Faster beam interpolation in frequency

### DIFF
--- a/fftvis/tests/test_compare_matvis.py
+++ b/fftvis/tests/test_compare_matvis.py
@@ -119,7 +119,7 @@ def test_simulate():
     assert fvis.shape == (nfreqs, ntimes, nants, nants)
 
     # Check that the results are the same
-    assert np.allclose(mvis, fvis, atol=1e-5)
+    assert np.allclose(mvis, fvis, atol=1e-4)
 
 
 def test_simulate_non_coplanar():


### PR DESCRIPTION
This PR matches the beam interpolation done in `matvis` where interpolation is first done in frequency, then over time. This should reduce interpolation time when there are many times in a simulation. 