### PR TITLE
Allow alternative spatial beam interpolators in UVBeam

### DIFF
--- a/fftvis/beams.py
+++ b/fftvis/beams.py
@@ -10,6 +10,7 @@ def _evaluate_beam(
     polarized: bool,
     freq: float,
     check: bool = False,
+    interpolator: str="RectBivariateSpline",
     spline_opts: dict = None,
 ):
     """Evaluate the beam on the CPU. Simplified version of the `_evaluate_beam_cpu` function
@@ -20,26 +21,30 @@ def _evaluate_beam(
 
     Parameters
     ----------
-    A_s
+    A_s: np.ndarray
         Array of shape (nax, nfeed, nsrcs_up) that will be filled with beam
         values.
-    beam
+    beam: UVBeam
         UVBeam object to evaluate.
-    tx, ty
+    tx, ty: np.ndarray
         Coordinates to evaluate the beam at, in sin-projection.
-    polarized
+    polarized: bool
         Whether to use beam polarization.
-    freq
+    freq: float
         Frequency to interpolate beam to.
-    check
+    check: bool
         Whether to check that the beam has no inf/nan values. Set to False if you are
         sure that the beam is valid, as it will be faster.
+    interpolator: str
+        Interpolation function to use when interpolating the beam. Options are
+        "RectBivariateSpline" and "map_coordinates".
     spline_opts
-        Extra options to pass to the RectBivariateSpline class when interpolating.
+        Extra keyword arguments to pass to the chosen interpolation function when interpolating.
     """
     # Primary beam pattern using direct interpolation of UVBeam object
     kw = (
         {
+            "spatial_interp_func": interpolator,
             "reuse_spline": True,
             "check_azza_domain": False,
             "spline_opts": spline_opts,

--- a/fftvis/beams.py
+++ b/fftvis/beams.py
@@ -35,7 +35,7 @@ def _evaluate_beam(
     check: bool
         Whether to check that the beam has no inf/nan values. Set to False if you are
         sure that the beam is valid, as it will be faster.
-    interpolator: str
+    spatial_interp_func: str
         Interpolation function to use when interpolating the angular axes of the beam. Options are
         "RectBivariateSpline" and "map_coordinates".
     spline_opts

--- a/fftvis/beams.py
+++ b/fftvis/beams.py
@@ -10,7 +10,7 @@ def _evaluate_beam(
     polarized: bool,
     freq: float,
     check: bool = False,
-    interpolator: str="RectBivariateSpline",
+    spatial_interp_func: str="RectBivariateSpline",
     spline_opts: dict = None,
 ):
     """Evaluate the beam on the CPU. Simplified version of the `_evaluate_beam_cpu` function
@@ -36,7 +36,7 @@ def _evaluate_beam(
         Whether to check that the beam has no inf/nan values. Set to False if you are
         sure that the beam is valid, as it will be faster.
     interpolator: str
-        Interpolation function to use when interpolating the beam. Options are
+        Interpolation function to use when interpolating the angular axes of the beam. Options are
         "RectBivariateSpline" and "map_coordinates".
     spline_opts
         Extra keyword arguments to pass to the chosen interpolation function when interpolating.
@@ -44,7 +44,7 @@ def _evaluate_beam(
     # Primary beam pattern using direct interpolation of UVBeam object
     kw = (
         {
-            "spatial_interp_func": interpolator,
+            "spatial_interp_func": spatial_interp_func,
             "reuse_spline": True,
             "check_azza_domain": False,
             "spline_opts": spline_opts,

--- a/fftvis/simulate.py
+++ b/fftvis/simulate.py
@@ -37,6 +37,7 @@ def simulate_vis(
     eps: float = None,
     use_feed: str = "x",
     beam_interpolator: str = "RectBivariateSpline",
+    beam_spline_opts: dict = None,
     live_progress: bool = True,
     max_progress_reports: int = 100,
 ):
@@ -87,6 +88,8 @@ def simulate_vis(
         "RectBivariateSpline" tends to be slower but more accurate, especially at the
         edges of the beam. Both methods produce the same results when linear interpolation
         is used.
+    beam_spline_opts : dict, optional
+        Options to pass to :meth:`pyuvdata.uvbeam.UVBeam.interp` as `spline_opts`.
     live_progress : bool, optional
         Whether to show a live progress bar. Default is True.
     max_progress_reports : int, optional

--- a/fftvis/simulate.py
+++ b/fftvis/simulate.py
@@ -123,6 +123,7 @@ def simulate(
     precision: int = 2,
     polarized: bool = False,
     eps: float | None = None,
+    beam_interpolator: str = "RectBivariateSpline",
     beam_spline_opts: dict = None,
     max_progress_reports: int = 100,
     live_progress: bool = True,
@@ -164,6 +165,12 @@ def simulate(
         - 2: float64, complex128
     eps : float, default = 6e-8
         Desired accuracy of the non-uniform fast fourier transform.
+    beam_interpolator : str, optional
+        Interpolation function to use when interpolating the beam. Options are
+        "RectBivariateSpline" and "map_coordinates". Default is "RectBivariateSpline".
+        "RectBivariateSpline" tends to be slower but more accurate, especially at the
+        edges of the beam. Both methods produce the same results when linear interpolation
+        is used.
     beam_spline_opts : dict, optional
         Options to pass to :meth:`pyuvdata.uvbeam.UVBeam.interp` as `spline_opts`.
 
@@ -309,6 +316,7 @@ def simulate(
                     za,
                     polarized,
                     freqs[fi],
+                    interpolator=beam_interpolator,
                     spline_opts=beam_spline_opts,
                 )
                 A_s = A_s.transpose((1, 0, 2))

--- a/fftvis/simulate.py
+++ b/fftvis/simulate.py
@@ -9,6 +9,7 @@ from rich.progress import Progress
 import logging
 import tracemalloc as tm
 from pyuvdata import UVBeam
+from pyuvsim import AnalyticBeam
 
 from . import utils, beams, logutils
 
@@ -28,13 +29,16 @@ def simulate_vis(
     dec: np.ndarray,
     freqs: np.ndarray,
     lsts: np.ndarray,
-    beam,
+    beam: UVBeam | AnalyticBeam,
     baselines: list[tuple] = None,
     precision: int = 2,
     polarized: bool = False,
     latitude: float = -0.5361913261514378,
     eps: float = None,
     use_feed: str = "x",
+    beam_interpolator: str = "RectBivariateSpline",
+    live_progress: bool = True,
+    max_progress_reports: int = 100,
 ):
     """
     Parameters:
@@ -75,6 +79,18 @@ def simulate_vis(
         Desired accuracy of the non-uniform fast fourier transform. If None, the default accuracy
         for the given precision will be used. For precision 1, the default accuracy is 6e-8, and for
         precision 2, the default accuracy is 1e-12.
+    use_feed : str, optional
+        Which feed to use for the beam. Options are "x" and "y". Default is "x".
+    beam_interpolator : str, optional
+        Interpolation function to use when interpolating the beam. Options are
+        "RectBivariateSpline" and "map_coordinates". Default is "RectBivariateSpline".
+        "RectBivariateSpline" tends to be slower but more accurate, especially at the
+        edges of the beam. Both methods produce the same results when linear interpolation
+        is used.
+    live_progress : bool, optional
+        Whether to show a live progress bar. Default is True.
+    max_progress_reports : int, optional
+        Maximum number of progress reports to show. Default is 100.
 
     Returns:
     -------
@@ -109,6 +125,9 @@ def simulate_vis(
         precision=precision,
         polarized=polarized,
         eps=eps,
+        beam_interpolator=beam_interpolator,
+        live_progress=live_progress,
+        max_progress_reports=max_progress_reports,
     )
 
 

--- a/fftvis/simulate.py
+++ b/fftvis/simulate.py
@@ -83,7 +83,7 @@ def simulate_vis(
     use_feed : str, optional
         Which feed to use for the beam. Options are "x" and "y". Default is "x".
     beam_interpolator : str, optional
-        Interpolation function to use when interpolating the beam. Options are
+        Interpolation function to use when interpolating the angular axes of the beam. Options are
         "RectBivariateSpline" and "map_coordinates". Default is "RectBivariateSpline".
         "RectBivariateSpline" tends to be slower but more accurate, especially at the
         edges of the beam. Both methods produce the same results when linear interpolation
@@ -131,6 +131,7 @@ def simulate_vis(
         beam_interpolator=beam_interpolator,
         live_progress=live_progress,
         max_progress_reports=max_progress_reports,
+        beam_spline_opts=beam_spline_opts,
     )
 
 
@@ -188,7 +189,7 @@ def simulate(
     eps : float, default = 6e-8
         Desired accuracy of the non-uniform fast fourier transform.
     beam_interpolator : str, optional
-        Interpolation function to use when interpolating the beam. Options are
+        Interpolation function to use when interpolating the angular axes of the beam. Options are
         "RectBivariateSpline" and "map_coordinates". Default is "RectBivariateSpline".
         "RectBivariateSpline" tends to be slower but more accurate, especially at the
         edges of the beam. Both methods produce the same results when linear interpolation
@@ -338,7 +339,7 @@ def simulate(
                     za,
                     polarized,
                     freqs[fi],
-                    interpolator=beam_interpolator,
+                    spatial_interp_func=beam_interpolator,
                     spline_opts=beam_spline_opts,
                 )
                 A_s = A_s.transpose((1, 0, 2))


### PR DESCRIPTION
This PR allows the user to choose between the beam interpolation function (either `RectBivariateSpline` or `map_coordinates` currently) along the angular axes of the beam.