### PR TITLE
New keyword argument to check if an array is flat to within some tolerance

### DIFF
--- a/fftvis/simulate.py
+++ b/fftvis/simulate.py
@@ -35,6 +35,7 @@ def simulate_vis(
     latitude: float = -0.5361913261514378,
     eps: float = None,
     use_feed: str = "x",
+    flat_array_tol: float = 0.0,
 ):
     """
     Parameters:
@@ -75,6 +76,10 @@ def simulate_vis(
         Desired accuracy of the non-uniform fast fourier transform. If None, the default accuracy
         for the given precision will be used. For precision 1, the default accuracy is 6e-8, and for
         precision 2, the default accuracy is 1e-12.
+    flat_array_tol : float, default = 0.0
+        Tolerance for checking if the array is flat in units of meters. If the
+        z-coordinate of all baseline vectors is within this tolerance, the array
+        is considered flat and the z-coordinate is set to zero. Default is 0.0.
 
     Returns:
     -------
@@ -109,6 +114,7 @@ def simulate_vis(
         precision=precision,
         polarized=polarized,
         eps=eps,
+        flat_array_tol=flat_array_tol,
     )
 
 
@@ -126,6 +132,7 @@ def simulate(
     beam_spline_opts: dict = None,
     max_progress_reports: int = 100,
     live_progress: bool = True,
+    flat_array_tol: float = 0.0,
 ):
     """
     Parameters:
@@ -166,6 +173,10 @@ def simulate(
         Desired accuracy of the non-uniform fast fourier transform.
     beam_spline_opts : dict, optional
         Options to pass to :meth:`pyuvdata.uvbeam.UVBeam.interp` as `spline_opts`.
+    flat_array_tol : float, default = 0.0
+        Tolerance for checking if the array is flat in units of meters. If the
+        z-coordinate of all baseline vectors is within this tolerance, the array
+        is considered flat and the z-coordinate is set to zero. Default is 0.0.
 
     Returns:
     -------
@@ -235,7 +246,8 @@ def simulate(
         :, :
     ].T.astype(real_dtype)
 
-    is_coplanar = np.allclose(blz, 0)
+    # Check if the array is flat within tolerance
+    is_coplanar = np.all(np.less_equal(np.abs(blz), flat_array_tol))
 
     # Generate visibility array
     if expand_vis:

--- a/fftvis/tests/test_compare_matvis.py
+++ b/fftvis/tests/test_compare_matvis.py
@@ -159,3 +159,11 @@ def test_simulate_non_coplanar():
 
     # Check that the results are the same
     assert np.allclose(mvis, fvis, atol=1e-5)
+
+    # Use fftvis to simulate visibilities with flat array
+    fvis_flat = simulate.simulate_vis(
+        antpos, sky_model, ra, dec, freqs, lsts, beam, precision=2, eps=1e-10, flat_array_tol=np.inf
+    )
+
+    # Check that the results are different
+    assert not np.allclose(fvis, fvis_flat, atol=1e-5)


### PR DESCRIPTION
This PR adds a new keyword argument `flat_array_tol` to `fftvis.simulate.simulate` that checks if an array is flat to within some tolerance. If all baselines are found to have z-components less than the tolerance set by `flay_array_tol`, the z-component of the array is set to zero.