### PR TITLE
Allow fftvis to accept polarized sky models

### DIFF
--- a/fftvis/beams.py
+++ b/fftvis/beams.py
@@ -77,7 +77,7 @@ def _evaluate_beam(
     parallel=False,
     nogil=False
 )
-def get_apparent_flux_polarized(beam: np.ndarray, flux: np.ndarray):  # pragma: no cover
+def get_apparent_flux_polarized_beam(beam: np.ndarray, flux: np.ndarray):  # pragma: no cover
     """Calculate apparent flux of the sources."""
     nax, nfd, nsrc = beam.shape
     
@@ -101,3 +101,98 @@ def get_apparent_flux_polarized(beam: np.ndarray, flux: np.ndarray):  # pragma: 
         beam[0, 1, isrc] = i01 * flux[isrc]
         beam[1, 0, isrc] = np.conj(i01) * flux[isrc]
         beam[1, 1, isrc] = i11 * flux[isrc]
+
+@nb.jit(
+    nopython=True,
+    parallel=False,
+    nogil=False
+)
+def get_apparent_flux_polarized(beam: np.ndarray, coherency: np.ndarray): # pragma: no cover
+    """
+    Compute the matrix product A^H * C * A for each 2x2 matrix A in a stack.
+    
+    Parameters
+    ----------
+    beam : np.ndarray
+        An array of shape (2, 2, nstack) where each beam[:,:,i] is a 2x2 matrix A.
+    C : np.ndarray
+        A (2, 2, nstack) matrix.
+        
+    Returns
+    -------
+    out : np.ndarray
+        An array of shape (2, 2, nstack) where each slice is the result of A * C * A^H.
+    """
+    nstack = beam.shape[2]
+    
+    for i in range(nstack):
+        # Unpack elements of A from the i-th slice.
+        a00 = beam[0, 0, i]
+        a01 = beam[0, 1, i]
+        a10 = beam[1, 0, i]
+        a11 = beam[1, 1, i]
+        
+        # First multiplication: Compute tmp = A * C.
+        tmp00 = np.conj(a00) * coherency[0, 0, i] + np.conj(a01) * coherency[1, 0, i]
+        tmp01 = np.conj(a00) * coherency[0, 1, i] + np.conj(a10) * coherency[1, 1, i]
+        tmp10 = np.conj(a01) * coherency[0, 0, i] + np.conj(a11) * coherency[1, 0, i]
+        tmp11 = np.conj(a01) * coherency[0, 1, i] + np.conj(a11) * coherency[1, 1, i]
+        
+        # Second multiplication: Multiply tmp by A^H.
+        # A^H is the conjugate transpose of A.
+        beam[0, 0, i] = tmp00 * a00 + tmp01 * a10
+        beam[0, 1, i] = tmp00 * a01 + tmp01 * a11
+        beam[1, 0, i] = tmp10 * a00 + tmp11 * a10
+        beam[1, 1, i] = tmp10 * a01 + tmp11 * a11
+
+@nb.jit(
+    nopython=True,
+    parallel=False,
+    nogil=False
+)
+def get_apparent_flux_polarized_asymmetric_beam(beam1, coherency, beam2):
+    """
+    Compute the matrix product A^H * C * B for each 2x2 matrix in the stacks.
+    
+    Parameters
+    ----------
+    beam1 : np.ndarray
+        A 3D array of shape (2, 2, nstack) where each A[:,:,i] is a 2x2 matrix.
+    coherency : np.ndarray
+        A 3D array of shape (2, 2, nstack) where each C[:,:,i] is a 2x2 matrix.
+    beam2 : np.ndarray
+        A 3D array of shape (2, 2, nstack) where each B[:,:,i] is a 2x2 matrix.
+    """
+    nstack = beam1.shape[2]
+    
+    for i in range(nstack):
+        # Unpack elements of A for the i-th slice.
+        a00 = beam1[0, 0, i]
+        a01 = beam1[0, 1, i]
+        a10 = beam1[1, 0, i]
+        a11 = beam1[1, 1, i]
+        
+        # Unpack elements of C for the i-th slice.
+        c00 = coherency[0, 0, i]
+        c01 = coherency[0, 1, i]
+        c10 = coherency[1, 0, i]
+        c11 = coherency[1, 1, i]
+        
+        # Unpack elements of B for the i-th slice.
+        b00 = beam2[0, 0, i]
+        b01 = beam2[0, 1, i]
+        b10 = beam2[1, 0, i]
+        b11 = beam2[1, 1, i]
+        
+        # Compute the intermediate product: T = A^H * C.
+        # A^H is the conjugate transpose of A.
+        t00 = np.conj(a00) * c00 + np.conj(a10) * c10
+        t01 = np.conj(a00) * c01 + np.conj(a10) * c11
+        t10 = np.conj(a01) * c00 + np.conj(a11) * c10
+        t11 = np.conj(a01) * c01 + np.conj(a11) * c11
+        
+        # Compute the final product: out = T * B = A^H * C * B.
+        beam1[0, 0, i] = t00 * b00 + t01 * b10
+        beam1[0, 1, i] = t00 * b01 + t01 * b11
+        beam1[1, 0, i] = t10 * b00 + t11 * b10
+        beam1[1, 1, i] = t10 * b01 + t11 * b11

--- a/fftvis/simulate.py
+++ b/fftvis/simulate.py
@@ -153,13 +153,13 @@ def simulate_vis(
         beam = prepare_beam_unpolarized(beam, use_feed=use_feed)
 
     # Sky model should either be unpolarized or have shape (nsources, nfreqs, 4)
-    if not (
-        (polarized and len(fluxes.shape) == 3 and fluxes.shape[-1] != 4) or 
-        (polarized and len(fluxes.shape) != 2)
-    ): 
-        raise ValueError(
-            "If polarized is True, fluxes must have shape (4, nsources, nfreqs) or (nsources, nfreqs)."
-        )
+    #if not (
+    #    (polarized and len(fluxes.shape) == 3 and fluxes.shape[-1] != 4) or 
+    #    (polarized and len(fluxes.shape) != 2)
+    #): 
+    #    raise ValueError(
+    #        "If polarized is True, fluxes must have shape (4, nsources, nfreqs) or (nsources, nfreqs)."
+    #    )
 
     return simulate(
         ants=ants,

--- a/fftvis/simulate.py
+++ b/fftvis/simulate.py
@@ -70,7 +70,7 @@ def simulate_vis(
         The Stokes I intensity will be split equally between the two linear polarization channels, 
         resulting in a factor of 0.5 from the value inputted here. This is done even if only one 
         polarization channel is simulated. If an array of size (nsources, nfreqs, 4) is provided,
-        it will be used to be the full set of stokes paraeters (I, Q, U, and V). Full stokes input
+        it will be used to be the full set of stokes parameters (I, Q, U, and V). Full stokes input
         is only accepted if polarized=True.
     ra, dec : array_like
         Arrays of source RA and Dec positions in radians. RA goes from [0, 2 pi]

--- a/fftvis/simulate.py
+++ b/fftvis/simulate.py
@@ -149,6 +149,14 @@ def simulate_vis(
     if not polarized:
         beam = prepare_beam_unpolarized(beam, use_feed=use_feed)
 
+    # Sky model should either be unpolarized or have shape (4, nsources, nfreqs)
+    #if (polarized and len(fluxes.shape) != 3 and fluxes.shape[0] != 4) or (
+    #    polarized and len(fluxes.shape) != 2
+    #):
+    #    raise ValueError(
+    #        "If polarized is True, fluxes must have shape (4, nsources, nfreqs) or (nsources, nfreqs)."
+    #    )
+
     return simulate(
         ants=ants,
         freqs=freqs,
@@ -495,6 +503,7 @@ def _evaluate_vis_chunk(
     complex_dtype: np.dtype,
     nfeeds: int,
     polarized: bool = False,
+    polarized_sky: bool = False,
     eps: float | None = None,
     beam_spline_opts: dict = None,
     interpolation_function: str = "az_za_map_coordinates",
@@ -561,7 +570,7 @@ def _evaluate_vis_chunk(
                 ).astype(complex_dtype)
                 #logutils.printmem(pr, f"[{time_index+1}/{nt_here} | {freqidx}] After BeamInterp")
                 if polarized:
-                    beams.get_apparent_flux_polarized(A_s, flux[:nsim_sources, freqidx])    
+                    beams.get_apparent_flux_polarized_beam(A_s, flux[:nsim_sources, freqidx])    
                 else:
                     A_s *= flux[:nsim_sources, freqidx]
 

--- a/fftvis/utils.py
+++ b/fftvis/utils.py
@@ -174,6 +174,28 @@ def get_task_chunks(nprocesses: int, nfreqs: int, ntimes: int) -> tuple[int, lis
     time_chunks = sum(([slice(i*nt, min(ntimes, (i + 1)*nt))]*nfc for i in range(ntc)), start=[])
     return nprocesses, freq_chunks, time_chunks, nf, nt
 
+def stokes_to_coherency(stokes: np.ndarray) -> np.ndarray:
+    """
+    Convert Stokes parameters to coherency matrix.
+
+    Parameters
+    ----------
+    stokes : np.ndarray
+        Stokes parameters in the form [I, Q, U, V].
+    
+    Returns
+    -------
+    coherency : np.ndarray
+        Coherency matrix.
+    """
+    coherency = 0.5 * np.array(
+        [
+            [stokes[..., 0] + stokes[..., 3], stokes[..., 1] + 1j * stokes[..., 2]],
+            [stokes[..., 1] - 1j * stokes[..., 2], stokes[..., 0] - stokes[..., 3]]
+        ]
+    )
+    return coherency
+
 @nb.jit(nopython=True)
 def inplace_rot(rot: np.ndarray, b: np.ndarray):  # pragma: no cover
     """In-place rotation of coordinates."""


### PR DESCRIPTION
This PR allows users to pass in polarized source models via I, Q, U, and V stokes parameters.