### PR TITLE
ci: add a lot of nice infrastructure to help maintain the package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,88 @@
+---
+# Labels names are important as they are used by Release Drafter to decide
+# regarding where to record them in changelog or if to skip them.
+#
+# The repository labels will be automatically configured using this file and
+# the GitHub Action https://github.com/marketplace/actions/github-labeler.
+- name: "API breaking"
+  description: Breaking Changes
+  color: e305fc
+- name: "good first issue"
+  description: Good for newcomers
+  color: 7057ff
+
+- name: "status: duplicate"
+  description: This issue or pull request already exists
+  color: d93f0b
+- name: "status: invalid"
+  description: Invalid issue or pull request
+  color: d93f0b
+- name: "status: requires discussion"
+  description: Issue requires further discussion before implementation
+  color: f71bd2
+- name: "status: requires research"
+  description: Issue requires further research before implementation
+  color: "d93f0b"
+- name: "status: wontfix"
+  description: Valid issue, but out of scope for future fixes
+  color: "d93f0b"
+
+- name: "type: maint: dependencies"
+  description: Pull requests that update a dependency file
+  color: "0366d6"
+- name: "type: maint: documentation"
+  description: Improvements or additions to documentation
+  color: "0075ca"
+- name: "type: maint: refactoring"
+  description: Refactoring
+  color: ef67c4
+- name: "type: maint: removal"
+  description: Removals and Deprecations
+  color: 9ae7ea
+- name: "type: maint: style"
+  description: Style
+  color: c120e5
+- name: "type: maint: build"
+  description: Build System and Dependencies
+  color: bfdadc
+
+- name: "type: accuracy"
+  description: "Enhancement that improves accuracy"
+  color: "bfd4f2"
+- name: "type: bug"
+  description: Something isn't working
+  color: d73a4a
+- name: "type: feature: ui"
+  description: New feature that adds functionality for the user
+  color: "0e8a16"
+- name: "type: feature: physical"
+  description: New feature that adds new analysis/physical model
+  color: "0e8a16"
+- name: "type: testing"
+  description: Testing improvements
+  color: b1fc6f
+- name: "type: performance: memory"
+  description: Performance improvements that reduce memory usage
+  color: "016175"
+- name: "type: performance: cpu"
+  description: Performance improvements that reduce runtime on cpu
+  color: "016175"
+- name: "type: performance: gpu"
+  description: Performance improvements that reduce runtime on gpu"
+  color: "016175"
+- name: "type: ci"
+  description: Updates to CI (GH actions, RTD, etc.)
+  color: "000000"
+- name: "type: question"
+  description: A question about the code or documentation
+  color: d876e3
+
+- name: "priority: low"
+  description: Low priority
+  color: "BFD4F2"
+- name: "priority: medium"
+  description: Medium priority
+  color: "E99695"
+- name: "priority: high"
+  description: High priority
+  color: "B60205"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,78 @@
+# See https://github.com/marketplace/actions/release-drafter for configuration
+categories:
+  - title: ":boom: Breaking Changes"
+    labels:
+      - "API breaking"
+  - title: ":rocket: Features"
+    labels:
+      - "type: feature: ui"
+      - "type: feature: physical"
+  - title: ":fire: Removals and Deprecations"
+    labels:
+      - "type: maint: removal"
+  - title: ":beetle: Fixes"
+    labels:
+      - "type: bug"
+  - title: ":racehorse: Performance and Accuracy"
+    labels:
+      - "type: performance: memory"
+      - "type: performance: cpu"
+      - "type: performance: gpu"
+      - "type: accuracy"
+  - title: ":rotating_light: Testing"
+    labels:
+      - "type: testing"
+  - title: ":construction_worker: Continuous Integration"
+    labels:
+      - "type: ci"
+  - title: ":books: Documentation"
+    labels:
+      - "type: maint: documentation"
+  - title: ":hammer: Refactoring"
+    labels:
+      - "type: maint: refactoring"
+  - title: ":lipstick: Style"
+    labels:
+      - "type: maint: style"
+  - title: ":package: Dependencies"
+    labels:
+      - "type: maint: dependencies"
+      - "type: maint: build"
+
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+autolabeler:
+  - label: 'type: maint: documentation'
+    files:
+      - '*.md'
+      - '*.rst'
+      - 'docs/**/*'
+    branch:
+      - '/.*docs{0,1}.*/'
+  - label: 'type: bug'
+    branch:
+      - '/fix.*/'
+    title:
+      - '/fix/i'
+  - label: "type: maint: removal"
+    title:
+      - "/remove .*/i"
+  - label: "type: ci"
+    files:
+      - '.github/*'
+      - '.pre-commit-config.yaml'
+      - '.coveragrc'
+    branch:
+      - '/pre-commit-ci-update-config/'
+  - label: "type: maint: style"
+    files:
+      - '/pre-commit-ci-update-config/'
+  - label: "type: maint: refactoring"
+    title:
+      - "/.* refactor.*/i"
+
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -1,0 +1,14 @@
+name: auto-merge
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor
+          github-token: ${{ secrets.AUTO_MERGE }}

--- a/.github/workflows/auto-merge-precommit.yml
+++ b/.github/workflows/auto-merge-precommit.yml
@@ -1,0 +1,22 @@
+name: pre-commit auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.title == '[pre-commit.ci] pre-commit autoupdate'
+    steps:
+      - name: Approve the PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Enable auto-merge
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -1,0 +1,27 @@
+name: Check Distribution Build
+
+on: push
+
+jobs:
+  check-build:
+    name: Twine Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install Build Tools
+        run: pip install build twine
+
+      - name: Build a binary wheel
+        run: |
+          python -m build .
+
+      - name: Check Distribution
+        run: |
+          twine check dist/*

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,30 @@
+name: Publish Python distributions to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-n-publish:
+    name: Make Release on PyPI and Github
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Build Tools
+        run: pip install build
+
+      - name: Build a binary wheel
+        run: |
+          python -m build .
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.12.4
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: Labeler
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Run Labeler
+        uses: crazy-max/ghaction-github-labeler@v5.2.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -1,0 +1,21 @@
+name: Update Draft Release
+
+on: push
+
+jobs:
+  draft-release:
+    name: Update Draft Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Publish the release notes
+        uses: release-drafter/release-drafter@v6.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+requires = ["setuptools>=64", "setuptools_scm>8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
This adds some nice CI infrastructure to help us maintain the package more easily, including:

- Github labels maintained within the code
- Automatic construction of Release Drafts
- Automatic deployment to pypi when a release is published
- Some automation of labelling of PRs given certain files that have been modified, or keywords in the branch name
- Checking the build every push
- Automatic udpates of CI action versions, as well as automatic merging of such updates if they pass tests
- Automatic merging of pre-commit updates