### PR TITLE
Move initial beam interpolation to the wrapper script

### DIFF
--- a/src/fftvis/cpu/cpu_simulate.py
+++ b/src/fftvis/cpu/cpu_simulate.py
@@ -144,11 +144,6 @@ class CPUSimulationEngine(SimulationEngine):
         # Get number of baselines
         nbls = len(baselines)
 
-        if isinstance(beam, UVBeam):
-            # Only try to interpolate the beam if it has more than one frequency
-            if hasattr(beam, "Nfreqs") and beam.Nfreqs > 1:
-                beam = beam.interp(freq_array=freqs, new_object=True, run_check=False) # pragma: no cover
-
         # Factor of 0.5 accounts for splitting Stokes between polarization channels
         Isky = 0.5 * fluxes
 

--- a/src/fftvis/wrapper.py
+++ b/src/fftvis/wrapper.py
@@ -3,6 +3,7 @@ import numpy as np
 from astropy.coordinates import EarthLocation
 from astropy.time import Time
 from pyuvdata.beam_interface import BeamInterface
+from pyuvdata import UVBeam
 from matvis.core.beams import prepare_beam_unpolarized
 
 from .core.beams import BeamEvaluator
@@ -197,6 +198,15 @@ def simulate_vis(
 
     # Make sure antpos has the right format
     ants = {k: np.array(v) for k, v in ants.items()}
+
+    # Interpolate the beam to the desired frequencies to avoid redundant
+    # interpolation in the simulation engine
+    if isinstance(beam, UVBeam):
+        if hasattr(beam, "Nfreqs") and beam.Nfreqs > 1:
+            beam = beam.interp(freq_array=freqs, new_object=True, run_check=False) # pragma: no cover
+    elif isinstance(beam, BeamInterface) and beam._isuvbeam:
+        if hasattr(beam.beam, "Nfreqs") and beam.beam.Nfreqs > 1:
+            beam.beam = beam.beam.interp(freq_array=freqs, new_object=True, run_check=False)
 
     beam = BeamInterface(beam)
 


### PR DESCRIPTION
This PR moves the initial beam interpolation to the wrapper script to avoid frequency interpolation of the beam happening in each time step. The newest version of `fftvis` only checked for `UVBeam` objects, not `BeamInterface` objects. Since we're now converting the input beam to a `BeamInterface` object, this initial frequency interpolation was never triggered. This PR now checks for a `UVBeam` or `BeamInterface` object and interpolates to the requested frequencies prior to passing the beam to the simulation engine.