### PR TITLE
fix: don't try to grid arrays with only autos

### DIFF
--- a/src/fftvis/core/antenna_gridding.py
+++ b/src/fftvis/core/antenna_gridding.py
@@ -108,6 +108,11 @@ def find_lattice_basis(
     # filter out zeros
     norms = np.linalg.norm(blvec, axis=1)
     mask = norms > tol
+    
+    if not np.any(mask):
+        # There are only autos, break early.
+        return None
+    
     blvec = blvec[mask]
     norms = norms[mask]
 
@@ -178,6 +183,10 @@ def check_antpos_griddability(
         antpos,
         tol=tol,
     )
+    if basis_2D is None:
+        # If all antennas are autos, return the original positions
+        return False, antpos, np.eye(antvecs.shape[-1])
+    
     basis = np.zeros((3, 3))
     basis[:2, :2] = basis_2D
     basis[2, 2] = 1.0

--- a/tests/test_antenna_gridding.py
+++ b/tests/test_antenna_gridding.py
@@ -7,6 +7,10 @@ from fftvis.core.antenna_gridding import check_antpos_griddability
 # ------------------------------------------------------------------
 # helpers / fixtures
 # ------------------------------------------------------------------
+def _only_autos(n=1):
+    """Only auto-correlations, no baselines."""
+    return {i: np.array([0.0, 0.0, 0.0]) for i in range(n)}
+
 def _linear_array(n=10, spacing=1.5):
     return {i: np.array([i * spacing, 0.0, 0.0]) for i in range(n)}
 
@@ -61,6 +65,8 @@ def _hex_grid():
         pytest.param(_square_grid_with_holes(), True, id="square-holey"),
         pytest.param(_hex_grid(), True, id="hex-grid"),
         pytest.param(_scattered_xy(), False, id="non‑griddable"),
+        pytest.param(_only_autos(), False, id="autos-only"),
+        pytest.param(_only_autos(2), False, id="autos-only-2"),
     ],
 )
 def test_check_antpos_griddability(antpos, expected_griddable):


### PR DESCRIPTION
This just fixes the antenna gridding functions so that if an array with only autos is passed, it doesn't error, but instead just doesn't try to grid. `hera_sim` tests were failing because some of them simulate only autos.