### PR TITLE
Add an extra check of beam_idx and beam_list in CPUSimulationEngine

### DIFF
--- a/src/fftvis/core/utils.py
+++ b/src/fftvis/core/utils.py
@@ -353,3 +353,78 @@ def get_desired_chunks(
     )
 
     return nchunks, int(np.ceil(nsrc / nchunks))
+
+
+def validate_beam_idx(
+    beam_idx: np.ndarray | None,
+    beam_coefs: np.ndarray | None,
+    nbeam: int,
+    nant: int,
+) -> np.ndarray | None:
+    """Validate and normalize ``beam_idx`` against the beam/antenna counts.
+
+    This encodes the antenna-to-beam mapping rules shared by the public
+    ``simulate_vis`` wrapper and the simulation engines, so that the two entry
+    points cannot drift out of sync.
+
+    Two mutually exclusive modes are supported:
+
+    - **Per-antenna beams** (``beam_coefs is None``): ``beam_list`` holds one
+      beam per unique beam in the array, and ``beam_idx`` maps each antenna to
+      one of them. If ``beam_idx`` is omitted it is inferred when unambiguous
+      (one beam shared by all antennas, or exactly ``nant`` beams).
+    - **Eigenbeams** (``beam_coefs is not None``): ``beam_list`` holds ``K``
+      basis beams whose count need not relate to ``nant``, and the mapping is
+      defined by ``beam_coefs``. ``beam_idx`` must not be supplied in this mode.
+
+    Parameters
+    ----------
+    beam_idx : np.ndarray or None
+        Array of integers, length ``nant``, mapping each antenna to a beam in
+        the beam list. May be None to request inference (per-antenna mode only).
+    beam_coefs : np.ndarray or None
+        Per-antenna eigenbeam coefficients. When not None, the eigenbeam path is
+        in use and ``beam_idx`` is irrelevant.
+    nbeam : int
+        Number of beams in the beam list.
+    nant : int
+        Number of antennas.
+
+    Returns
+    -------
+    np.ndarray or None
+        The validated ``beam_idx``. In per-antenna mode this may be a freshly
+        inferred array; in eigenbeam mode it is returned unchanged (None).
+
+    Raises
+    ------
+    ValueError
+        If ``beam_idx`` is supplied alongside ``beam_coefs``; if it cannot be
+        inferred because ``nbeam`` is neither 1 nor ``nant``; if it has the
+        wrong shape; or if it contains out-of-range beam indices.
+    """
+    if beam_coefs is not None:
+        if beam_idx is not None:
+            raise ValueError(
+                "beam_idx should not be provided when beam_coefs is given. "
+                "The mapping from antennas to beams is defined by beam_coefs."
+            )
+        return beam_idx
+
+    if beam_idx is None:
+        if nbeam == nant:
+            beam_idx = np.arange(nant)
+        elif nbeam != 1:
+            raise ValueError(
+                "If number of beams provided is not 1 or nant, beam_idx must be provided."
+            )
+
+    if beam_idx is not None:
+        if beam_idx.shape != (nant,):
+            raise ValueError("beam_idx must be length nant")
+        if not all(0 <= i < nbeam for i in beam_idx):
+            raise ValueError(
+                "beam_idx contains indices greater than the number of beams"
+            )
+
+    return beam_idx

--- a/src/fftvis/cpu/cpu_simulate.py
+++ b/src/fftvis/cpu/cpu_simulate.py
@@ -583,6 +583,8 @@ class CPUSimulationEngine(SimulationEngine):
         # Get sizes of inputs
         nfreqs = np.size(freqs)
         ntimes = len(times)
+        nbeam = len(beam_list)
+        nant = len(ants)
 
         nax = nfeeds = 2 if polarized else 1
 
@@ -602,6 +604,22 @@ class CPUSimulationEngine(SimulationEngine):
             dec = dec.astype(real_dtype)
         if freqs.dtype != real_dtype:
             freqs = freqs.astype(real_dtype)
+
+        # Check beam_idx validity against input beams and antennas.
+        if beam_idx is None:
+            if nbeam == nant:
+                beam_idx = np.arange(nant)
+            elif nbeam != 1:
+                raise ValueError(
+                    "If number of beams provided is not 1 or nant, beam_idx must be provided."
+                )
+        if beam_idx is not None:
+            if beam_idx.shape != (nant,):
+                raise ValueError("beam_idx must be length nant")
+            if not all(0 <= i < nbeam for i in beam_idx):
+                raise ValueError(
+                    "beam_idx contains indices greater than the number of beams"
+                )
 
         # Get the redundant groups
         if baselines is None:

--- a/src/fftvis/cpu/cpu_simulate.py
+++ b/src/fftvis/cpu/cpu_simulate.py
@@ -605,21 +605,10 @@ class CPUSimulationEngine(SimulationEngine):
         if freqs.dtype != real_dtype:
             freqs = freqs.astype(real_dtype)
 
-        # Check beam_idx validity against input beams and antennas.
-        if beam_idx is None:
-            if nbeam == nant:
-                beam_idx = np.arange(nant)
-            elif nbeam != 1:
-                raise ValueError(
-                    "If number of beams provided is not 1 or nant, beam_idx must be provided."
-                )
-        if beam_idx is not None:
-            if beam_idx.shape != (nant,):
-                raise ValueError("beam_idx must be length nant")
-            if not all(0 <= i < nbeam for i in beam_idx):
-                raise ValueError(
-                    "beam_idx contains indices greater than the number of beams"
-                )
+        # Validate / infer the antenna-to-beam mapping. The shared helper keeps
+        # this logic identical between the wrapper and the simulation engine, and
+        # correctly no-ops on the eigenbeam path (beam_coefs is not None).
+        beam_idx = utils.validate_beam_idx(beam_idx, beam_coefs, nbeam, nant)
 
         # Get the redundant groups
         if baselines is None:

--- a/src/fftvis/utils.py
+++ b/src/fftvis/utils.py
@@ -14,6 +14,7 @@ from .core.utils import (
     get_task_chunks,
     get_desired_chunks,
     get_required_chunks,
+    validate_beam_idx,
 )
 
 
@@ -40,4 +41,5 @@ __all__ = [
     "inplace_rot",
     "get_desired_chunks",
     "get_required_chunks",
+    "validate_beam_idx",
 ]

--- a/src/fftvis/wrapper.py
+++ b/src/fftvis/wrapper.py
@@ -11,7 +11,7 @@ from .core.beams import BeamEvaluator
 from .cpu.beams import CPUBeamEvaluator
 from .core.simulate import SimulationEngine, default_accuracy_dict
 from .cpu.cpu_simulate import CPUSimulationEngine
-from .core.utils import get_desired_chunks
+from .core.utils import get_desired_chunks, validate_beam_idx
 
 def create_beam_evaluator(
     backend: Literal["cpu", "gpu"] = "cpu", **kwargs
@@ -252,29 +252,9 @@ def simulate_vis(
     nbeam = len(_beam_list)
     nant = len(ants)
 
-    # Check the beam indices — skip entirely when eigenbeams are being used,
-    # since beam_coefs maps antennas to basis beams and beam_idx is irrelevant.
-    if beam_coefs is not None:
-        if beam_idx is not None:
-            raise ValueError(
-                "beam_idx should not be provided when beam_coefs is given. "
-                "The mapping from antennas to beams is defined by beam_coefs."
-            )
-    else:
-        if beam_idx is None:
-            if nbeam == nant:
-                beam_idx = np.arange(nant)
-            elif nbeam != 1:
-                raise ValueError(
-                    "If number of beams provided is not 1 or nant, beam_idx must be provided."
-                )
-        if beam_idx is not None:
-            if beam_idx.shape != (nant,):
-                raise ValueError("beam_idx must be length nant")
-            if not all(0 <= i < nbeam for i in beam_idx):
-                raise ValueError(
-                    "beam_idx contains indices greater than the number of beams"
-                )
+    # Validate / infer the antenna-to-beam mapping. The shared helper keeps this
+    # logic identical between the wrapper and the simulation engine.
+    beam_idx = validate_beam_idx(beam_idx, beam_coefs, nbeam, nant)
 
     beam_list = []
 


### PR DESCRIPTION
This PR adds an additional check to CPUSimulationEngine class of `fftvis` to make sure the beam_list and beam_idx inputs are reasonable. In the case that a user calls CPUSimulationEngine.simulate, no checks are applied. Given how some of the later bits of code are written, this can lead to the simulator only using the first beam in the beam list if `beam_idx` is not applied and a list of beams is given. We now check to make sure a beam_idx is provided if the number of beams passed is greater than 1.