### PR TITLE
Fix bug in checking array flatness tolerance

### DIFF
--- a/src/fftvis/cpu/cpu_simulate.py
+++ b/src/fftvis/cpu/cpu_simulate.py
@@ -646,15 +646,18 @@ class CPUSimulationEngine(SimulationEngine):
                 ant: rotated_antvecs[:, antkey_to_idx[ant]] for ant in ants
             }
             rotation_matrix = rotation_matrix.astype(real_dtype)
-
+            
             bls = np.array([rotated_ants[bl[1]] - rotated_ants[bl[0]] for bl in baselines])[
                 :, :
             ].T
-            bls /= utils.speed_of_light
-            bls = bls.astype(real_dtype)
 
             # Check if the array is flat within tolerance
             is_coplanar = np.all(np.less_equal(np.abs(bls[2]), flat_array_tol))
+
+            # Scale the baseline vectors by the speed of light to convert to seconds
+            bls /= utils.speed_of_light
+            bls = bls.astype(real_dtype)
+
         else:
             logger.info(
                 "Using gridded coordinates for the array. Type 1 transform will be used."

--- a/src/fftvis/cpu/cpu_simulate.py
+++ b/src/fftvis/cpu/cpu_simulate.py
@@ -646,7 +646,7 @@ class CPUSimulationEngine(SimulationEngine):
                 ant: rotated_antvecs[:, antkey_to_idx[ant]] for ant in ants
             }
             rotation_matrix = rotation_matrix.astype(real_dtype)
-            
+
             bls = np.array([rotated_ants[bl[1]] - rotated_ants[bl[0]] for bl in baselines])[
                 :, :
             ].T

--- a/src/fftvis/cpu/cpu_simulate.py
+++ b/src/fftvis/cpu/cpu_simulate.py
@@ -654,7 +654,7 @@ class CPUSimulationEngine(SimulationEngine):
             # Check if the array is flat within tolerance
             is_coplanar = np.all(np.less_equal(np.abs(bls[2]), flat_array_tol))
 
-            # Scale the baseline vectors by the speed of light to convert to seconds
+            # Divide the baseline vectors by the speed of light to convert to seconds
             bls /= utils.speed_of_light
             bls = bls.astype(real_dtype)
 


### PR DESCRIPTION
This PR fixes a bug in the flat-array check used to decide whether `fftvis` can drop the baseline `z` component and use the 2D NUFFT path.

Previously, the code divided baseline vectors by the speed of light before applying `flat_array_tol`. As a result, `flat_array_tol` was effectively interpreted in seconds of delay rather than meters. With the default value of `1e-6`, this could incorrectly classify many physically non-coplanar arrays as flat, causing their `w` terms to be discarded before visibility calculation.

This PR applies the flatness check while baseline vectors are still in meters, then converts the baselines to delay units for downstream use.